### PR TITLE
active_model_serializers を使用した article-list の route を作成

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class ArticlesController < BaseApiController # base_api_controller を継承
+    def index
+      articles = Article.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,0 +1,3 @@
+class Api::V1::BaseApiController < ApplicationController
+
+end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,3 +1,2 @@
 class Api::V1::BaseApiController < ApplicationController
-
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,7 +2,6 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :article_likes, dependent: :destroy
   has_many :comments, dependent: :destroy
-
   validates :body, presence: true
   validates :title, presence: true, length: { maximum: 45 }
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'auth'
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get 'articles/index'
+  namespace :api do
+    namespace :v1 do
+      mount_devise_token_auth_for 'User', at: 'auth'
+      resources :articles
+    end
+  end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -92,3 +92,6 @@ Style/HashSyntax:
 
 RSpec/EmptyExampleGroup:
   Enabled: false
+
+RSpec/EmptyLineAfterSubject:
+  Enabled: false

--- a/config/rubocop/rubocop.yml
+++ b/config/rubocop/rubocop.yml
@@ -420,3 +420,12 @@ Style/HashTransformKeys:
 # version 1 からは強制 true
 Style/HashTransformValues:
   Enabled: true
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  Enabled: false
+
+Layout/SpaceInsideParens:
+  Enabled: false

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -1,23 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Articles", type: :request do
-
   describe "GET /articles" do
     subject { get(api_v1_articles_path) }
-    let!(:article_1) {create(:article, updated_at: 1.days.ago)}
-    let!(:article_2) {create(:article, updated_at: 2.days.ago)}
-    let!(:article_3) {create(:article)}
+    let!(:article_1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article_2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article_3) { create(:article) }
 
-    fit "記事一覧が取得できる" do
+    it "記事一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
 
       expect(res.length).to eq 3
       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-      expect(res.map {|d| d["id"]}).to eq [article_3.id, article_1.id, article_2.id]
+      expect(res.map {|d| d["id"]} ).to eq [article_3.id, article_1.id, article_2.id]
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/articles_request_spec.rb
+++ b/spec/requests/articles_request_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+    let!(:article_1) {create(:article, updated_at: 1.days.ago)}
+    let!(:article_2) {create(:article, updated_at: 2.days.ago)}
+    let!(:article_3) {create(:article)}
+
+    fit "記事一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      expect(res.map {|d| d["id"]}).to eq [article_3.id, article_1.id, article_2.id]
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
## 概要
 - request spec にて 記事一覧を返す API のテストずみ