### PR TITLE
devise_token_auth を使用した ユーザーの新規登録テストの実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,13 @@
+module Api::V1::Auth
+  class RegistrationsController < DeviseTokenAuth::RegistrationsController
+    private
+
+      def sign_up_params
+        params.permit(:name, :email, :password, :password_confirmation)
+      end
+
+      def account_update_params
+        params.permit(:name, :email)
+      end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,6 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: 'api/v1/auth/registrations',
+      }
       resources :articles
     end
   end

--- a/spec/requests/api/v1/auth/registrations_request_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_request_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+    context "必要なカラムが送信されているとき" do
+      let(:params) { attributes_for(:user) }
+      it "ユーザーが新規登録される。" do
+        expect { subject }.to change { User.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect( res["data"]["email"]).to eq( User.last.email )
+      end
+
+      it "header 情報を取得できる" do
+        subject
+        resheader = response.header
+        expect(resheader["access-token"]).to be_present
+        expect(resheader["client"]).to be_present
+        expect(resheader["token-type"]).to be_present
+        expect(resheader["uid"]).to be_present
+      end
+    end
+
+    context "name カラムが送信されていないとき" do
+      let(:params) { attributes_for(:user, name: nil)}
+      it "エラーする" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(res["errors"]["full_messages"]).to include "Name can't be blank"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "email が存在しないとき" do
+      let(:params) { attributes_for(:user, email: nil) }
+
+      it "エラーする" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["email"]).to include "can't be blank"
+      end
+    end
+
+    context "password が存在しないとき" do
+      let(:params) { attributes_for(:user, password: nil) }
+
+      it "エラーする" do
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["password"]).to include "can't be blank"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 補足
- header 情報の設定も行う。